### PR TITLE
Added window.location to allow accessing from anywhere

### DIFF
--- a/client/webrtc.js
+++ b/client/webrtc.js
@@ -12,7 +12,7 @@ function pageReady() {
     localVideo = document.getElementById('localVideo');
     remoteVideo = document.getElementById('remoteVideo');
 
-    serverConnection = new WebSocket('ws://127.0.0.1:3434');
+    serverConnection = new WebSocket('ws://' + window.location.hostname + ':3434');
     serverConnection.onmessage = gotMessageFromServer;
 
     var constraints = {


### PR DESCRIPTION
With this fix, you can serve the HTML/JS from any server, not only localhost,  and still have the code connecting to the proper websocket.
